### PR TITLE
Fix broken env vars

### DIFF
--- a/cntlm-helm/templates/deployment.yaml
+++ b/cntlm-helm/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
              value: {{ .Values.cntlm.domain }}
            {{ end }}
            {{ if .Values.cntlm.username }}
-           - name: CNTLM_USER
+           - name: CNTLM_USERNAME
              value: {{ .Values.cntlm.username }}
            {{ end }}
            {{ if .Values.cntlm.passlm }}
@@ -61,14 +61,14 @@ spec:
                secretKeyRef:
                  name: {{ include "cntlm.fullname" . }}-secret
                  key: cntlm_passnt
-           {{ end }}                 
+           {{ end }}
            {{ if .Values.cntlm.passntlmv2 }}
-           - name: CNTLM_PASSNTLMv2
+           - name: CNTLM_PASSNTLMV2
              valueFrom:
                secretKeyRef:
                  name: {{ include "cntlm.fullname" . }}-secret
-                 key: cntlm_passntlmv2 
-           {{ end }}             
+                 key: cntlm_passntlmv2
+           {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cntlm-helm/templates/secret.yaml
+++ b/cntlm-helm/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
-data:
+stringData:
   {{ if .Values.cntlm.passlm }}
   cntlm_passlm: {{ .Values.cntlm.passlm }}
   {{ end }}

--- a/cntlm-helm/values.yaml
+++ b/cntlm-helm/values.yaml
@@ -38,7 +38,7 @@ cntlm:
  proxy: 45.55.27.15:8080
 
 
-resources: 
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
The docker image `bachp/cntlm` uses different env vars for username and hashed secret. And to work with `Opaque` secret, `stringData` is preferred over `data`.

To check env vars: `docker run --rm --entrypoint cat bachp/cntlm /run.sh`